### PR TITLE
Simplify terms query

### DIFF
--- a/solutions/06-terms-query.json
+++ b/solutions/06-terms-query.json
@@ -1,14 +1,10 @@
 {
   "query": {
-    "filtered": {
-      "filter": {
-        "terms": {
-          "topping": [
-            "Bacon",
-            "Marinated Chicken"
-          ]
-        }
-      }
+    "terms": {
+      "topping": [
+        "Bacon",
+        "Marinated Chicken"
+      ]
     }
   }
 }

--- a/tests_bdd/06-terms-query.feature
+++ b/tests_bdd/06-terms-query.feature
@@ -17,6 +17,13 @@ Feature: Term level queries (exact terms)
           {
             "_source":{
               "topping":[
+                "Marinated Chicken"
+              ]
+            }
+          },
+          {
+            "_source":{
+              "topping":[
                 "Bacon"
               ]
             }
@@ -27,13 +34,6 @@ Feature: Term level queries (exact terms)
                 "Meatballs",
                 "Marinated Beef",
                 "Bacon"
-              ]
-            }
-          },
-          {
-            "_source":{
-              "topping":[
-                "Marinated Chicken"
               ]
             }
           }


### PR DESCRIPTION
The "filtered" query is deprecated. See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filtered-query.html and https://www.elastic.co/blog/better-query-execution-coming-elasticsearch-2-0

We have used the filtered query in our solution proposal for task 06. We do not have to use filter here, so I suggest that we remove it for this task. This will simplify the task a bit, and it will also be a more natural progression after having done task 05.

However, when doing this, the ordering of hits in the response changes, so I had to rearrange these in order for the tests to pass.
