### PR TITLE
Update solution for bool query

### DIFF
--- a/solutions/07-bool-query.json
+++ b/solutions/07-bool-query.json
@@ -1,26 +1,20 @@
 {
   "query": {
-    "filtered": {
-      "filter": {
-        "bool": {
-          "must": [
-            {
-              "query": {
-                "match": {
-                  "name": "California"
-                }
-              }
-            },
-            {
-              "query": {
-                "term": {
-                  "topping": "Meatballs"
-                }
-              }
-            }
-          ]
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "name": "California"
+          }
         }
-      }
+      ],
+      "filter": [
+        {
+          "term": {
+            "topping": "Meatballs"
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Given that "filtered" is deprecated, I thought it would be a good idea to remove it from this solution. At the same time, I believe it is best to use "must" when querying the name and "filter" for the topping. 

We want to have a score for the name query (so we use "must" there), but for the topping, we just care if it is a match or not (so we use "filter").
