### PR TITLE
Show that "aggs" must be on same level as "query"

### DIFF
--- a/tests_bdd/09-terms-aggregations.feature
+++ b/tests_bdd/09-terms-aggregations.feature
@@ -2,6 +2,17 @@ Feature: Aggregations
 
   # Use https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
 
+  # Note that "aggs" should be on the same level as "query" and not inside a query, like this:
+  # {
+  #   "query" : {
+  #      ...
+  #   },
+  #   "aggs" : {
+  #      ...
+  #    }
+  # }
+  # For this task you only need the "aggs".
+
   # Note that aggregations appear at the bottom of the response from Elasticsearch. If you
   # are using the Sense extension for Chrome, you may have to scroll down to the bottom of
   # the response window to see them.


### PR DESCRIPTION
Clarify that aggs should be on the same level as "query" and not inside a query.
This is not properly displayed when going directly to the elasticsearch aggs description.
